### PR TITLE
Fix card.ts - isThrowOut signature

### DIFF
--- a/src/app/modules/ionic-swing/interfaces/swing.ts
+++ b/src/app/modules/ionic-swing/interfaces/swing.ts
@@ -87,12 +87,13 @@ export interface StackConfig {
      *
      * Element is considered to be thrown out when throwOutConfidence is equal to 1.
      *
-     * param {Number} offset Distance from the dragStart.
+     * param {Number} offsetX Distance from the dragStart.
+     * param {Number} offsetY Distance from the dragStart.
      * param {HTMLElement} element Element.
      * param {Number} throwOutConfidence config.throwOutConfidence
      * return {Boolean}
      */
-    isThrowOut?: (offset: number, element: HTMLElement, throwOutConfidence: number) => boolean;
+    isThrowOut?: (offsetX: number, offsetY: number, element: HTMLElement, throwOutConfidence: number) => boolean;
 
     /**
      * Returns a value between 0 and 1 indicating the completeness of the throw out condition.


### PR DESCRIPTION
I've been using your package (which is awesome by the way) to work on a basic Ionic app and have come across an issue.  

When calling `config.isThrowOut` on line 296 of card.ts is uses the incorrect signature and so it doesn't call my override of `config.throwOutConfidence` in my StackConfig. 

I believe I've fixed the issue in this pull request. 

PS: I'm a bit rusty at all this so please forgive me if I've not followed the right process for reporting the issue or raising the pull request.

Thanks!